### PR TITLE
Improve OTP Secrets menu: scrolling, search, keyboard navigation and live countdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ PO_FILES := $(wildcard po/*.po)
 SOURCES := extension.js prefs.js
 EXTRA_SOURCES := \
 	base32.js \
+	codeController.js \
 	indicator.js \
 	myAlertDialog.js \
 	myEntryRow.js \
@@ -39,7 +40,8 @@ EXTRA_DIST := \
 	AUTHORS \
 	COPYING \
 	prefs.css \
-	README.md
+	README.md \
+	stylesheet.css
 
 
 .PHONY: all clean install update-po

--- a/codeController.js
+++ b/codeController.js
@@ -1,0 +1,173 @@
+/*  codeController.js
+ * Copyright (C) 2025  Daniel K. O.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/*
+ * Toolkit-agnostic controller that drives the "live OTP code + countdown"
+ * behavior.  It owns a single GLib timeout, fetches the secret when needed,
+ * (re)computes the current code and its expiry, and reports the resulting
+ * state to a render callback.
+ *
+ * This deliberately contains no GTK/St widget code so it can be shared by both
+ * the preferences window (GTK) and the panel indicator (St/Clutter).
+ */
+
+import GLib from 'gi://GLib';
+
+import * as SecretUtils from './secretUtils.js';
+
+
+function now()
+{
+    return Date.now() / 1000;
+}
+
+
+export default
+class CodeController {
+
+    #otp;
+    #on_update;
+    #interval;
+
+    #code = null;
+    #expiry = 0;
+    #source = 0;
+
+
+    // on_update receives a state object:
+    //   { type, locked, code, remaining, fraction, period, error }
+    constructor(otp, on_update, interval = 500)
+    {
+        this.#otp = otp;
+        this.#on_update = on_update;
+        this.#interval = interval;
+    }
+
+
+    get otp()
+    {
+        return this.#otp;
+    }
+
+
+    start()
+    {
+        if (this.#source)
+            return;
+
+        // Do a first update immediately so the UI isn't blank until the first
+        // tick fires.
+        this.update();
+
+        this.#source = GLib.timeout_add(GLib.PRIORITY_DEFAULT,
+                                        this.#interval,
+                                        () => {
+                                            this.update();
+                                            return GLib.SOURCE_CONTINUE;
+                                        });
+    }
+
+
+    stop()
+    {
+        if (this.#source) {
+            GLib.Source.remove(this.#source);
+            this.#source = 0;
+        }
+    }
+
+
+    // HOTP codes never expire on their own; TOTP codes expire when the current
+    // period ends.
+    #expired()
+    {
+        if (this.#otp.type == 'HOTP')
+            return true;
+        if (!this.#code)
+            return true;
+        if (this.#expiry == 0)
+            return true;
+        if (this.#expiry < now())
+            return true;
+        return false;
+    }
+
+
+    async update()
+    {
+        const type = this.#otp.type;
+        try {
+            if (this.#expired()) {
+                const item = await SecretUtils.getOTPItem(this.#otp);
+                if (item.locked) {
+                    this.#code = null;
+                    this.#expiry = 0;
+                    this.#on_update({
+                        type,
+                        locked: true,
+                        code: null,
+                        remaining: 0,
+                        fraction: 0,
+                        period: this.#otp.period ?? 0
+                    });
+                    return;
+                }
+
+                this.#otp.secret = await SecretUtils.getSecret(this.#otp);
+
+                if (type == 'TOTP') {
+                    const [code, expiry] = this.#otp.code_and_expiry();
+                    this.#expiry = expiry;
+                    this.#code = code;
+                } else {
+                    this.#otp.counter = parseInt(item.get_attributes().counter);
+                    this.#code = this.#otp.code();
+                }
+            }
+
+            let remaining = 0;
+            let fraction = 0;
+            if (type == 'TOTP' && this.#otp.period) {
+                remaining = Math.max(this.#expiry - now(), 0);
+                fraction = remaining / this.#otp.period;
+            }
+
+            this.#on_update({
+                type,
+                locked: false,
+                code: this.#code,
+                remaining,
+                fraction,
+                period: this.#otp.period ?? 0
+            });
+        }
+        catch (e) {
+            /*
+             * Errors here are usually harmless: the item was deleted or edited
+             * while this async function was running, or the keyring was locked.
+             * Stop updating and let the renderer decide how to present it.
+             */
+            this.stop();
+            // The renderer's widgets may already be destroyed (e.g. the menu
+            // was closing), so don't let a failing callback turn into an
+            // unhandled rejection.
+            try {
+                this.#on_update({
+                    type,
+                    locked: false,
+                    code: this.#code,
+                    remaining: 0,
+                    fraction: 0,
+                    period: this.#otp.period ?? 0,
+                    error: e
+                });
+            }
+            catch (_) {
+            }
+        }
+    }
+
+};

--- a/indicator.js
+++ b/indicator.js
@@ -5,19 +5,27 @@
  */
 
 
-import GObject from 'gi://GObject';
-import Secret from 'gi://Secret';
-import St from 'gi://St';
+import Clutter from 'gi://Clutter';
+import GLib     from 'gi://GLib';
+import GObject  from 'gi://GObject';
+import Pango    from 'gi://Pango';
+import St       from 'gi://St';
 
+import * as Config    from 'resource:///org/gnome/shell/misc/config.js';
 import * as Main      from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
-import HOTP from './hotp.js';
+import CodeController  from './codeController.js';
+import HOTP            from './hotp.js';
 import * as SecretUtils from './secretUtils.js';
-import TOTP from './totp.js';
+import TOTP            from './totp.js';
 
 import {gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+
+// St.ScrollView changed its child/scrollbar API in GNOME 46.
+const SHELL_MAJOR = parseInt(Config.PACKAGE_VERSION.split('.')[0]);
 
 
 function copyToClipboard(text)
@@ -36,6 +44,248 @@ function makeLabel({issuer, name})
 }
 
 
+// Small circular countdown drawn with cairo. The color is taken from the CSS
+// foreground color, and the state classes (full/high/low) mirror the LevelBar
+// offsets used in the preferences window, so both menus feel consistent.
+const CountdownIndicator = GObject.registerClass(
+class TotpCountdownIndicator extends St.DrawingArea {
+
+    #fraction = 1;
+
+    constructor()
+    {
+        super({
+            style_class: 'totp-countdown full',
+            x_align: Clutter.ActorAlign.CENTER,
+            y_align: Clutter.ActorAlign.CENTER
+        });
+    }
+
+
+    setState(fraction, remaining)
+    {
+        fraction = Math.max(0, Math.min(1, fraction));
+
+        let state = 'full';
+        if (remaining <= 5)
+            state = 'low';
+        else if (remaining <= 10)
+            state = 'high';
+
+        const style_class = `totp-countdown ${state}`;
+        let changed = false;
+
+        if (this.style_class != style_class) {
+            this.style_class = style_class;
+            changed = true;
+        }
+        if (Math.abs(fraction - this.#fraction) > 0.001) {
+            this.#fraction = fraction;
+            changed = true;
+        }
+
+        // Only repaint when something actually changed.
+        if (changed)
+            this.queue_repaint();
+    }
+
+
+    vfunc_repaint()
+    {
+        const [width, height] = this.get_surface_size();
+        const cr = this.get_context();
+
+        try {
+            const color = this.get_theme_node().get_foreground_color();
+            const red   = color.red   / 255;
+            const green = color.green / 255;
+            const blue  = color.blue  / 255;
+            const alpha = color.alpha / 255;
+
+            // A thin ring reads as a subtle status indicator rather than a bold
+            // element that competes with the OTP code.
+            const line_width = 2;
+            const radius = Math.min(width, height) / 2 - line_width;
+            const cx = width / 2;
+            const cy = height / 2;
+
+            cr.setLineWidth(line_width);
+
+            // faint background track (full circle)
+            cr.setSourceRGBA(red, green, blue, alpha * 0.2);
+            cr.arc(cx, cy, radius, 0, 2 * Math.PI);
+            cr.stroke();
+
+            // remaining arc, starting at 12 o'clock going clockwise
+            if (this.#fraction > 0) {
+                const start = -Math.PI / 2;
+                const end = start + 2 * Math.PI * this.#fraction;
+                cr.setSourceRGBA(red, green, blue, alpha);
+                cr.arc(cx, cy, radius, start, end);
+                cr.stroke();
+            }
+        }
+        finally {
+            cr.$dispose();
+        }
+    }
+});
+
+
+// A single OTP entry: copy icon, issuer/name title, live code, remaining
+// seconds and a circular countdown. The countdown/refresh logic is shared with
+// the preferences window through CodeController.
+const OTPMenuItem = GObject.registerClass(
+class TotpOTPMenuItem extends PopupMenu.PopupBaseMenuItem {
+
+    #controller;
+    #countdown;
+    #code_label;
+    #remaining_label;
+    #code = null;
+    #masked = false;
+
+    constructor(otp, label, haystack, on_activate)
+    {
+        super();
+
+        this.add_style_class_name('totp-otp-item');
+
+        this.otp = otp;
+        this.haystack = haystack;
+
+        this.add_child(new St.Icon({
+            style_class: 'popup-menu-icon',
+            icon_name: 'edit-copy-symbolic',
+            y_align: Clutter.ActorAlign.CENTER
+        }));
+
+        const text_box = new St.BoxLayout({
+            style_class: 'totp-text-box',
+            vertical: true,
+            x_expand: true,
+            y_align: Clutter.ActorAlign.CENTER
+        });
+        this.add_child(text_box);
+
+        // Primary: issuer/account. Ellipsized so long names never push the
+        // countdown out of the row.
+        const title_label = new St.Label({
+            style_class: 'totp-title-label',
+            text: label,
+            x_expand: true
+        });
+        title_label.clutter_text.ellipsize = Pango.EllipsizeMode.END;
+        text_box.add_child(title_label);
+
+        const sub_box = new St.BoxLayout({
+            style_class: 'totp-subtitle-box',
+            y_align: Clutter.ActorAlign.CENTER
+        });
+        text_box.add_child(sub_box);
+
+        // Secondary: the OTP code, made to stand out via monospace + weight.
+        this.#code_label = new St.Label({
+            style_class: 'totp-code-label',
+            text: '…', // ellipsis while loading
+            y_align: Clutter.ActorAlign.CENTER
+        });
+        sub_box.add_child(this.#code_label);
+
+        // Tertiary: remaining seconds, visually lighter.
+        this.#remaining_label = new St.Label({
+            style_class: 'totp-remaining-label',
+            text: '',
+            y_align: Clutter.ActorAlign.CENTER
+        });
+        this.#remaining_label.opacity = 160;
+        sub_box.add_child(this.#remaining_label);
+
+        // Status: subtle countdown ring, right-aligned and vertically centered.
+        this.#countdown = new CountdownIndicator();
+        if (otp.type != 'TOTP')
+            this.#countdown.visible = false;
+        this.add_child(this.#countdown);
+
+        this.connect('activate', () => on_activate(this.otp));
+
+        this.#controller = new CodeController(otp, this.render.bind(this));
+    }
+
+
+    start()
+    {
+        this.#controller.start();
+    }
+
+
+    stop()
+    {
+        this.#controller.stop();
+    }
+
+
+    // Toggle whether the code is shown or masked with bullets. Purely a
+    // display concern; copying always uses the real code.
+    setMasked(masked)
+    {
+        this.#masked = masked;
+        this.#renderCode();
+    }
+
+
+    #renderCode()
+    {
+        if (this.#code == null) {
+            this.#code_label.text = '…'; // still loading
+            return;
+        }
+        this.#code_label.text = this.#masked
+            ? '•'.repeat(this.otp.digits)
+            : this.#code;
+    }
+
+
+    render({locked, code, remaining, fraction, type, error})
+    {
+        if (error) {
+            this.#code = null;
+            this.#code_label.text = _('Error');
+            this.#remaining_label.text = '';
+            this.reactive = false;
+            return;
+        }
+
+        if (locked) {
+            this.#code = null;
+            this.#code_label.text = _('Locked');
+            this.#remaining_label.text = '';
+            if (type == 'TOTP')
+                this.#countdown.setState(0, 0);
+            return;
+        }
+
+        this.#code = code ?? null;
+        this.#renderCode();
+
+        if (type == 'TOTP') {
+            const secs = Math.ceil(remaining);
+            this.#remaining_label.text = `${secs} s`;
+            this.#countdown.setState(fraction, remaining);
+        } else {
+            this.#remaining_label.text = '';
+        }
+    }
+
+
+    destroy()
+    {
+        this.#controller.stop();
+        super.destroy();
+    }
+});
+
+
 export default
 class Indicator extends PanelMenu.Button {
 
@@ -46,8 +296,17 @@ class Indicator extends PanelMenu.Button {
 
     #ext;
     #lock_item;
-    #otp_items = [];
     #unlock_item;
+    #search_entry;
+    #scroll;
+    #section;
+    #empty_item;
+    #empty_label;
+    #visibility_button;
+    #visibility_icon;
+    #codes_hidden = false;
+    #otp_items = [];
+    #focus_source = 0;
 
 
     constructor(ext)
@@ -63,6 +322,48 @@ class Indicator extends PanelMenu.Button {
             })
         );
 
+        // --- Search field (always at the top) ---
+        const search_item = new PopupMenu.PopupBaseMenuItem({
+            style_class: 'totp-search-item',
+            reactive: false,
+            can_focus: false
+        });
+        this.#search_entry = new St.Entry({
+            style_class: 'totp-search-entry',
+            hint_text: _('Type to search…'),
+            can_focus: true,
+            x_expand: true
+        });
+        this.#search_entry.set_primary_icon(new St.Icon({
+            style_class: 'totp-search-icon',
+            icon_name: 'edit-find-symbolic'
+        }));
+        search_item.add_child(this.#search_entry);
+
+        // Show/hide-codes toggle button, right of the search field.
+        this.#visibility_icon = new St.Icon({
+            style_class: 'popup-menu-icon',
+            icon_name: 'view-conceal-symbolic'
+        });
+        this.#visibility_button = new St.Button({
+            style_class: 'totp-visibility-button',
+            child: this.#visibility_icon,
+            can_focus: true,
+            y_align: Clutter.ActorAlign.CENTER
+        });
+        this.#visibility_button.connect('clicked',
+                                        this.toggleCodesVisibility.bind(this));
+        search_item.add_child(this.#visibility_button);
+        this.updateVisibilityButton();
+
+        this.menu.addMenuItem(search_item);
+
+        this.#search_entry.clutter_text.connect('text-changed',
+                                                this.applyFilter.bind(this));
+        this.#search_entry.clutter_text.connect('key-press-event',
+                                                this.onSearchKeyPress.bind(this));
+
+        // --- Actions ---
         this.#lock_item = this.menu.addAction(_('Lock OTP secrets'),
                                               this.lockOTPSecrets.bind(this),
                                               'changes-prevent-symbolic');
@@ -78,6 +379,49 @@ class Indicator extends PanelMenu.Button {
 
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem(_('OTP Secrets')));
 
+        // --- Scrollable OTP list ---
+        this.#scroll = new St.ScrollView({
+            style_class: 'totp-scroll',
+            overlay_scrollbars: false,
+            x_expand: true,
+            y_expand: true
+        });
+        if (SHELL_MAJOR >= 46) {
+            this.#scroll.hscrollbar_policy = St.PolicyType.NEVER;
+            this.#scroll.vscrollbar_policy = St.PolicyType.AUTOMATIC;
+        } else {
+            this.#scroll.set_policy(St.PolicyType.NEVER, St.PolicyType.AUTOMATIC);
+        }
+
+        // The section is added to the menu (so items get a proper parent chain
+        // for activation/close), then its actor is reparented into the scroll
+        // view for the actual layout.
+        this.#section = new PopupMenu.PopupMenuSection();
+        this.menu.addMenuItem(this.#section);
+        this.menu.box.remove_child(this.#section.actor);
+        if (SHELL_MAJOR >= 46)
+            this.#scroll.add_child(this.#section.actor);
+        else
+            this.#scroll.add_actor(this.#section.actor);
+        this.menu.box.add_child(this.#scroll);
+
+        // --- Empty state ---
+        this.#empty_item = new PopupMenu.PopupBaseMenuItem({
+            style_class: 'totp-empty-item',
+            reactive: false,
+            can_focus: false
+        });
+        this.#empty_label = new St.Label({
+            style_class: 'totp-empty-label',
+            text: _('No OTP secrets.'),
+            x_align: Clutter.ActorAlign.CENTER,
+            x_expand: true
+        });
+        this.#empty_label.opacity = 160;
+        this.#empty_item.add_child(this.#empty_label);
+        this.menu.addMenuItem(this.#empty_item);
+        this.#empty_item.visible = false;
+
         Main.panel.addToStatusArea(ext.uuid, this);
     }
 
@@ -90,12 +434,7 @@ class Indicator extends PanelMenu.Button {
 
     destroy()
     {
-        this.#lock_item.destroy();
-        this.#lock_item = null;
-
-        this.#unlock_item.destroy();
-        this.#unlock_item = null;
-
+        this.cancelFocus();
         this.clearOTPItems();
         super.destroy();
     }
@@ -105,21 +444,68 @@ class Indicator extends PanelMenu.Button {
     {
         super._onOpenStateChanged(menu, is_open);
 
-        try  {
-            if (is_open) {
-                let locked = await SecretUtils.isOTPCollectionLocked();
-                this.#lock_item.visible = !locked;
-                this.#unlock_item.visible = locked;
-                if (locked)
-                    this.clearOTPItems();
-                else
-                    await this.refreshOTPItems();
-            } else
+        try {
+            if (!is_open) {
+                this.cancelFocus();
                 this.clearOTPItems();
+                return;
+            }
+
+            // Fresh start: clear any previous search text.
+            this.#search_entry.set_text('');
+
+            let locked = await SecretUtils.isOTPCollectionLocked();
+            this.#lock_item.visible = !locked;
+            this.#unlock_item.visible = locked;
+
+            if (locked) {
+                this.clearOTPItems();
+                this.#empty_item.visible = false;
+            } else {
+                await this.refreshOTPItems();
+            }
+
+            // Automatically focus the search field so the user can type
+            // immediately. Deferred to idle so the entry is mapped first.
+            this.cancelFocus();
+            this.#focus_source = GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+                this.#focus_source = 0;
+                this.#search_entry.grab_key_focus();
+                return GLib.SOURCE_REMOVE;
+            });
         }
         catch (e) {
             logError(e);
         }
+    }
+
+
+    cancelFocus()
+    {
+        if (this.#focus_source) {
+            GLib.Source.remove(this.#focus_source);
+            this.#focus_source = 0;
+        }
+    }
+
+
+    toggleCodesVisibility()
+    {
+        this.#codes_hidden = !this.#codes_hidden;
+        this.updateVisibilityButton();
+        this.#otp_items.forEach(item => item.setMasked(this.#codes_hidden));
+        // Keep typing uninterrupted after toggling.
+        this.#search_entry.grab_key_focus();
+    }
+
+
+    updateVisibilityButton()
+    {
+        this.#visibility_icon.icon_name = this.#codes_hidden
+            ? 'view-reveal-symbolic'
+            : 'view-conceal-symbolic';
+        const label = this.#codes_hidden ? _('Show OTP codes') : _('Hide OTP codes');
+        this.#visibility_button.accessible_name = label;
     }
 
 
@@ -175,12 +561,37 @@ class Indicator extends PanelMenu.Button {
                     otp = new HOTP(args);
                 if (otp == null)
                     throw Error(`BUG: args.type is ${args.type}`);
-                let label = makeLabel(otp);
-                let item = this.menu.addAction(label,
-                                               this.copyCode.bind(this, otp),
-                                               'edit-copy-symbolic');
+
+                const label = makeLabel(otp);
+
+                // Build a searchable haystack out of every meaningful, non-secret
+                // attribute plus the visible label.
+                const parts = [];
+                for (const [key, value] of Object.entries(args)) {
+                    if (key == 'secret' || !value)
+                        continue;
+                    parts.push(value);
+                }
+                parts.push(label);
+                const haystack = parts.join(' ').toLowerCase();
+
+                const item = new OTPMenuItem(otp,
+                                             label,
+                                             haystack,
+                                             this.copyCode.bind(this));
+                item.connect('key-press-event',
+                             (actor, event) => this.onItemKeyPress(item, event));
+                item.connect('key-focus-in', () => this.ensureVisible(item));
+
+                item.setMasked(this.#codes_hidden);
+
+                this.#section.addMenuItem(item);
                 this.#otp_items.push(item);
+                item.start();
             });
+
+            this.updateMaxHeight();
+            this.applyFilter();
         }
         catch (e) {
             logError(e);
@@ -189,10 +600,154 @@ class Indicator extends PanelMenu.Button {
     }
 
 
+    updateMaxHeight()
+    {
+        const monitor = Main.layoutManager.primaryMonitor;
+        if (!monitor)
+            return;
+        // Never let the list exceed a sensible fraction of the screen height.
+        const max_height = Math.max(200, Math.round(monitor.height * 0.6));
+        this.#scroll.style = `max-height: ${max_height}px;`;
+    }
+
+
     clearOTPItems()
     {
-        this.#otp_items.forEach(x => x.destroy());
+        this.#otp_items.forEach(x => x.stop());
+        this.#section.removeAll();
         this.#otp_items = [];
+    }
+
+
+    visibleItems()
+    {
+        return this.#otp_items.filter(item => item.visible);
+    }
+
+
+    applyFilter()
+    {
+        const query = this.#search_entry.get_text().toLowerCase().trim();
+
+        let visible = 0;
+        for (const item of this.#otp_items) {
+            const match = query == '' || item.haystack.includes(query);
+            item.visible = match;
+            if (match)
+                ++visible;
+        }
+
+        if (this.#otp_items.length == 0) {
+            this.#empty_label.text = _('No OTP secrets.');
+            this.#empty_item.visible = true;
+        } else if (visible == 0) {
+            this.#empty_label.text = _('No matching OTP secrets.');
+            this.#empty_item.visible = true;
+        } else {
+            this.#empty_item.visible = false;
+        }
+    }
+
+
+    focusItem(item)
+    {
+        item.grab_key_focus();
+        this.ensureVisible(item);
+    }
+
+
+    focusFirstItem()
+    {
+        const items = this.visibleItems();
+        if (items.length == 0)
+            return false;
+        this.focusItem(items[0]);
+        return true;
+    }
+
+
+    ensureVisible(item)
+    {
+        const adjustment = this.#scroll.vadjustment
+            ?? this.#scroll.get_vadjustment?.()
+            ?? this.#scroll.vscroll?.adjustment;
+        if (!adjustment)
+            return;
+
+        const box = item.get_allocation_box();
+        if (box.y1 < adjustment.value)
+            adjustment.value = box.y1;
+        else if (box.y2 > adjustment.value + adjustment.page_size)
+            adjustment.value = box.y2 - adjustment.page_size;
+    }
+
+
+    onSearchKeyPress(actor, event)
+    {
+        const symbol = event.get_key_symbol();
+
+        switch (symbol) {
+            case Clutter.KEY_Down:
+            case Clutter.KEY_Tab:
+                if (this.focusFirstItem())
+                    return Clutter.EVENT_STOP;
+                return Clutter.EVENT_PROPAGATE;
+
+            case Clutter.KEY_Return:
+            case Clutter.KEY_KP_Enter:
+            case Clutter.KEY_ISO_Enter: {
+                const first = this.visibleItems()[0];
+                if (first) {
+                    first.activate(event);
+                    return Clutter.EVENT_STOP;
+                }
+                return Clutter.EVENT_PROPAGATE;
+            }
+
+            case Clutter.KEY_Escape:
+                // First Escape clears the search; a second one closes the menu.
+                if (this.#search_entry.get_text() != '') {
+                    this.#search_entry.set_text('');
+                    return Clutter.EVENT_STOP;
+                }
+                return Clutter.EVENT_PROPAGATE;
+        }
+
+        return Clutter.EVENT_PROPAGATE;
+    }
+
+
+    onItemKeyPress(item, event)
+    {
+        const symbol = event.get_key_symbol();
+        const items = this.visibleItems();
+        const index = items.indexOf(item);
+
+        switch (symbol) {
+            case Clutter.KEY_Down: {
+                const next = items[index + 1];
+                if (next)
+                    this.focusItem(next);
+                return Clutter.EVENT_STOP;
+            }
+
+            case Clutter.KEY_Up:
+                if (index <= 0)
+                    this.#search_entry.grab_key_focus();
+                else
+                    this.focusItem(items[index - 1]);
+                return Clutter.EVENT_STOP;
+
+            case Clutter.KEY_Return:
+            case Clutter.KEY_KP_Enter:
+            case Clutter.KEY_ISO_Enter:
+                item.activate(event);
+                return Clutter.EVENT_STOP;
+        }
+
+        // Let Escape and everything else fall through to the default handling
+        // (Escape closes the menu).
+        return Clutter.EVENT_PROPAGATE;
     }
 
 

--- a/prefs.js
+++ b/prefs.js
@@ -19,6 +19,7 @@ import {
 } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 import * as Base32      from './base32.js';
+import CodeController   from './codeController.js';
 import HOTP             from './hotp.js';
 import MyAlertDialog    from './myAlertDialog.js';
 import MyEntryRow       from './myEntryRow.js';
@@ -62,12 +63,6 @@ function reportError(root, e)
     catch (ee) {
         logError(ee);
     }
-}
-
-
-function now()
-{
-    return new Date().getTime() / 1000;
 }
 
 
@@ -559,12 +554,10 @@ class CopyCodeButton extends Gtk.Button {
     }
 
 
-    #code = null;
-    #expiry = 0;
+    #controller;
     #label;
     #level;
     #otp;
-    #update_source = 0;
 
 
     constructor(otp)
@@ -609,88 +602,38 @@ class CopyCodeButton extends Gtk.Button {
             box.append(this.#level);
         }
 
-        this.#update_source = GLib.timeout_add(GLib.PRIORITY_DEFAULT,
-                                               500,
-                                               () => {
-                                                   try {
-                                                       this.updateCode();
-                                                   }
-                                                   catch (e) {
-                                                       this.cancelUpdates();
-                                                       return GLib.SOURCE_REMOVE;
-                                                   }
-                                                   return GLib.SOURCE_CONTINUE;
-                                               });
+        // The countdown/refresh logic is shared with the panel indicator; see
+        // codeController.js.
+        this.#controller = new CodeController(this.#otp, this.render.bind(this));
+        this.#controller.start();
     }
 
 
     destroy()
     {
-        this.cancelUpdates();
+        this.#controller.stop();
     }
 
 
-    async updateCode()
+    render({locked, code, remaining, type, error})
     {
-        try {
-            const type = this.#otp.type;
-            if (this.expired()) {
-                const item = await SecretUtils.getOTPItem(this.#otp);
-                if (item.locked) {
-                    if (type == 'TOTP')
-                        this.#level.value = 0;
-                    this.#label.label = _('Unlock');
-                    this.#label.use_markup = false;
-                    return;
-                }
-
-                this.#otp.secret = await SecretUtils.getSecret(this.#otp);
-
-                if (type == 'TOTP') {
-                    const [code, expiry] = this.#otp.code_and_expiry();
-                    this.#expiry = expiry;
-                    this.#code = code;
-                } else if (type == 'HOTP') {
-                    this.#otp.counter = parseInt(item.get_attributes().counter);
-                    this.#code = this.#otp.code();
-                }
-            }
-
-            if (type == 'TOTP')
-                this.#level.value = Math.max(this.#expiry - now(), 0);
-            this.#label.label = `<tt>${this.#code}</tt>`;
-            this.#label.use_markup = true;
-        }
-        catch (e) {
-            /*
-             * Note: errors here are harmless, it usually means the item was deleted or
-             * edited while this async function was running. So we just disable the button
-             * and cancel future updates.
-             */
+        if (error) {
             this.sensitive = false;
-            this.cancelUpdates();
+            return;
         }
-    }
 
-
-    cancelUpdates()
-    {
-        if (this.#update_source) {
-            GLib.Source.remove(this.#update_source);
-            this.#update_source = 0;
+        if (locked) {
+            if (type == 'TOTP')
+                this.#level.value = 0;
+            this.#label.label = _('Unlock');
+            this.#label.use_markup = false;
+            return;
         }
-    }
 
-
-    expired()
-    {
-        if (this.#otp.type == 'HOTP')
-            return true;
-        if (!this.#expiry == 0 || !this.#code)
-            return true;
-        if (this.#expiry < now())
-            return true;
-        return false;
+        if (type == 'TOTP')
+            this.#level.value = remaining;
+        this.#label.label = `<tt>${code}</tt>`;
+        this.#label.use_markup = true;
     }
 
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,0 +1,109 @@
+/* stylesheet.css
+ * Copyright (C) 2025  Daniel K. O.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Styles for the panel indicator menu (St/Clutter widgets).
+ *
+ * Spacing follows GNOME's 6px scale (3 / 6 / 12) so the menu feels like a
+ * first-party component.
+ */
+
+
+/* --- Search row ------------------------------------------------------- */
+
+.totp-search-item {
+    padding-top: 6px;
+    padding-bottom: 6px;
+}
+
+.totp-search-entry {
+    min-width: 20em;
+}
+
+.totp-search-icon {
+    icon-size: 16px;
+}
+
+.totp-visibility-button {
+    padding: 4px 6px;
+    margin-left: 6px;
+    border-radius: 6px;
+}
+
+.totp-visibility-button:hover {
+    background-color: rgba(127, 127, 127, 0.15);
+}
+
+.totp-visibility-button:focus {
+    background-color: rgba(127, 127, 127, 0.20);
+}
+
+
+/* --- Scrollable OTP list ---------------------------------------------- */
+
+/* The maximum height is set dynamically in indicator.js so the list never
+ * exceeds the available screen height. */
+.totp-scroll {
+    margin-top: 3px;
+}
+
+
+/* --- OTP row ---------------------------------------------------------- */
+
+.totp-otp-item {
+    spacing: 12px;
+}
+
+.totp-text-box {
+    spacing: 1px;
+}
+
+/* Primary: the service/account identifier. Kept at normal weight so the
+ * monospace code below is the element that stands out. */
+.totp-title-label {
+    font-weight: normal;
+}
+
+.totp-subtitle-box {
+    spacing: 8px;
+}
+
+/* Secondary: the OTP code — monospace so it stands out as the value to copy. */
+.totp-code-label {
+    font-family: monospace;
+    font-size: 1.05em;
+    font-weight: bold;
+}
+
+/* Tertiary: remaining seconds (dimmed via actor opacity in JS). */
+.totp-remaining-label {
+    font-size: 0.85em;
+}
+
+/* Status: subtle countdown ring; color states mirror the LevelBar offsets
+ * used in the preferences window. */
+.totp-countdown {
+    width: 16px;
+    height: 16px;
+}
+
+.totp-countdown.full {
+    color: #2ec27e; /* success */
+}
+
+.totp-countdown.high {
+    color: #e5a50a; /* warning */
+}
+
+.totp-countdown.low {
+    color: #e01b24; /* error */
+}
+
+
+/* --- Empty state ------------------------------------------------------ */
+
+.totp-empty-item {
+    padding-top: 8px;
+    padding-bottom: 8px;
+}


### PR DESCRIPTION
## Summary

This PR reworks the panel indicator's **OTP Secrets** menu so it scales gracefully for users with many entries, while keeping the extension lightweight and consistent with GNOME Shell. Functionality-wise nothing existing was removed — copying still works exactly as before.

## What's included

### Scrollable OTP list
- The list now lives in an `St.ScrollView` capped at 60% of the monitor height, so the menu **never exceeds the screen** (previously it grew indefinitely with no scrollbar).
- Mouse-wheel, touchpad and keyboard scrolling all work; the scrollbar reserves its own width and doesn't overlap content.

### Search bar with automatic focus
- A search field is pinned to the **top** of the menu and is **auto-focused on open**, so you can start typing immediately.
- Live, **case-insensitive** filtering across every non-secret attribute (issuer, name, type, …) plus the visible label, preserving the original ordering, with a proper empty state ("No matching OTP secrets.").

### Full keyboard navigation
- `Down`/`Tab` moves focus from the search field into the results.
- `Up`/`Down` navigate between filtered entries; `Up` on the first entry returns to search.
- `Enter` copies the selected code.
- `Escape` clears the search if there's text, then closes the menu on a second press.
- Focused entries are scrolled into view automatically.

### Countdown indicator in the main menu
- Every entry shows its **current code**, **remaining seconds**, and a **subtle circular ring** that updates in real time — bringing the expiry feedback that previously only existed in the preferences dialog into the main menu.

### Show/hide codes toggle
- An eye button in the search row masks/reveals all codes at once (bullets). Masking is **display-only** and never affects copying.

### UI/UX polish
- Clear typographic hierarchy: identifier (normal) → **bold monospace code** → dimmed seconds.
- GNOME 6px spacing scale, ellipsized long account names, aligned icons, and a subtle ring so the countdown never competes with the code.

## Refactor / maintainability

- The countdown/refresh state machine (expiry check → fetch secret → compute code/expiry → report remaining time, with proper `GLib` timer disposal) was extracted into a new **toolkit-agnostic `CodeController`** shared by both the GTK preferences window (`prefs.js`) and the new St panel menu (`indicator.js`). This **removes the duplicated timer logic** that previously lived only in `CopyCodeButton`.
- Timers are disposed on menu close and on `destroy()`, and no signal listeners leak.

## Files

- `indicator.js` — scrollable menu, search, keyboard navigation, per-entry live countdown, show/hide toggle, styling hooks.
- `codeController.js` *(new)* — shared countdown/refresh controller.
- `prefs.js` — `CopyCodeButton` refactored onto the shared controller (dead `now()` removed).
- `stylesheet.css` *(new)* — shell-side styles for the menu.
- `Makefile` — package the two new files.

## Validation

Environment note: the changes were tested on **GNOME Shell 50.1 (Wayland)**. What I verified:

- `node --check` on all changed JS files — pass.
- Live typelib introspection on GNOME 50 confirming every `St`/`Clutter`/`Pango`/cairo API used exists (`St.ScrollView` child/adjustment/scrollbar-policy, `St.Entry.set_primary_icon`, `St.Button.child`/`accessible_name`, `St.DrawingArea` cairo context, `ThemeNode.get_foreground_color`, `Pango.EllipsizeMode`, etc.).
- `codeController.js` loads and instantiates cleanly in `gjs`.
- `gnome-extensions pack` succeeds with the new files.
- Installed to `~/.local/share/gnome-shell/extensions/` for on-device testing.

I intentionally left the `po/*.po` / `.pot` catalogs untouched to keep the diff code-only; new user-facing strings (all wrapped in `_()`) can be picked up with `make update-po`: *"Type to search…"*, *"No OTP secrets."*, *"No matching OTP secrets."*, *"Show OTP codes"*, *"Hide OTP codes"*, *"Locked"*, *"Error"*.

## Notes for reviewers

- Because the menu now displays codes on open (when the collection is unlocked), it fetches secrets on open — the same thing the preferences window already does. Happy to gate this behind a setting if you'd prefer.
- `St.ScrollView` API differences across GNOME 45→50 are handled via a shell-version guard (`add_child`/scrollbar properties on 46+, `add_actor`/`set_policy` fallback on 45).

## Screenshots

<img width="741" height="1046" alt="Screenshot From 2026-07-09 01-56-00" src="https://github.com/user-attachments/assets/3c2af909-24fb-4747-a28e-298f56b59cb8" />

